### PR TITLE
Add support for partial updates and fix header bug

### DIFF
--- a/lib/qbt_client/version.rb
+++ b/lib/qbt_client/version.rb
@@ -1,3 +1,3 @@
 module QbtClient
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/lib/qbt_client/web_ui.rb
+++ b/lib/qbt_client/web_ui.rb
@@ -138,6 +138,45 @@ module QbtClient
       self.class.get('/query/torrents').parsed_response
     end
 
+    # Polls the client for incremental changes.
+    #
+    # @param interval Update interval in seconds.
+    #
+    # @yield [Hash] the return result of #sync.
+    def poll interval: 10, &block
+      raise '#poll requires a block' unless block_given?
+
+      response_id = 0
+
+      loop do
+        res = self.sync response_id
+
+        if res
+          yield res
+        end
+
+        sleep interval
+      end
+    end
+
+    # Requests partial data from the client.
+    #
+    # @param response_id [Integer] Response ID. Used to keep track of what has
+    #   already been sent by qBittorrent.
+    #
+    # @return [Hash, nil] parsed json data on success, nil otherwise
+    #
+    # @note Read more about `response_id` at https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-Documentation#get-partial-data
+    def sync response_id = 0
+      req = self.class.get '/sync/maindata', format: :json,
+                           query: { rid: response_id }
+      res = req.parsed_response
+
+      if req.success?
+        return res
+      end
+    end
+
     def torrent_data torrent_hash
       torrents = torrent_list
 

--- a/lib/qbt_client/web_ui.rb
+++ b/lib/qbt_client/web_ui.rb
@@ -7,7 +7,7 @@
 # Website::   http://ktechsystems.com
 ##############################################################################
 
-require 'json/pure'
+require 'multi_json'
 require 'httparty'
 require 'digest'
 

--- a/lib/qbt_client/web_ui.rb
+++ b/lib/qbt_client/web_ui.rb
@@ -490,6 +490,18 @@ module QbtClient
       self.class.post('/command/recheck', options)
     end
 
+    # Set location for a torrent
+    def set_location(torrent_hashes, path)
+      torrent_hashes = Array(torrent_hashes)
+      torrent_hashes = torrent_hashes.join('|')
+
+      options = {
+        body: { "hashes" => torrent_hashes, "location" => path },
+      }
+
+      self.class.post('/command/setLocation', options)
+    end
+
     ###
     # Increase the priority of one or more torrents
     #

--- a/lib/qbt_client/web_ui.rb
+++ b/lib/qbt_client/web_ui.rb
@@ -34,7 +34,7 @@ module QbtClient
       #self.class.digest_auth(user, pass)
       host = "#{ip}:#{port}"
       self.class.base_uri host
-      self.class.headers "Referer" => host
+      self.class.headers "Referer" => "http://#{host}"
       authenticate
       self.class.cookies.add_cookies(@sid)
     end

--- a/lib/qbt_client/web_ui.rb
+++ b/lib/qbt_client/web_ui.rb
@@ -152,6 +152,8 @@ module QbtClient
         res = self.sync response_id
 
         if res
+          response_id = res['rid']
+          
           yield res
         end
 

--- a/qbt_client.gemspec
+++ b/qbt_client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "httparty", "~> 0.7"
-  spec.add_runtime_dependency "json"
+  spec.add_runtime_dependency 'multi_json', '~> 1.13'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/lib/qbt_client/web_ui_spec.rb
+++ b/spec/lib/qbt_client/web_ui_spec.rb
@@ -675,6 +675,22 @@ describe WebUI do
     end
   end
 
+  context '#sync' do
+    it 'should first return a full update' do
+      client = WebUI.new(test_ip, test_port, test_user, test_pass)
+
+      expect(client.sync).to have_key('full_update')
+    end
+
+    it 'should not return full update for consecutive requests' do
+      client = WebUI.new(test_ip, test_port, test_user, test_pass)
+
+      result = client.sync
+      expect(result).to_not be_nil
+      expect(client.sync(result['rid'])).to_not have_key 'full_update'
+    end
+  end
+
   #context "test" do
 
   #  it "tests a torrent" do


### PR DESCRIPTION
Hi, this is a pull request that fixes a bug with the `Referer` header being wrong (qBittorrent expects it to start with http://).

It also adds support for receiving partial updates from qBittorrent.

`WebUI#poll` will continuously poll using `WebUI#sync` while automatically incrementing the response id, yielding partial updates.